### PR TITLE
Added include_regex source parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,13 @@ Internally uses the GitHub v4 API (GraphQL).
 * `access_token` : _Required_ (`string`). A GitHub API access token. This access token must have `repo` scope, and if the resource queries the repositories belonging to a team, it must also have `read:org` scope for the organization to which the team belongs.
 * `org` : _Required_ (`string`). The organization whose repositories should be listed.
 * `team` : _Optional_ (`string`). The team whose repositories should be listed. 
-* `exclude_regex` : _Optional_ (`string`). A regular expression of repositories which should not be included in the final list.
-* `exclude` : _Optional_ (`array[string]`). A list of repositories which should not be included in the final list. This list is appended to the `exclude_regex` to build a final exclusionary rule, and both `exclude` and `exclude_regex` may be specified.
+* `exclude_regex` : _Optional_ (`string`). A regular expression of repositories which should not be included in the final list. May not be specified when `include_regex` is specified.
+* `exclude` : _Optional_ (`array[string]`). A list of repositories which should not be included in the final list. This list is appended to the `exclude_regex` to build a final exclusionary rule, and both `exclude` and `exclude_regex` may be specified. May not be specified when `include_regex` is specified.
+* `include_regex` : _Optional_ (`string`). A regular expression of repository names which should be included in the final list. May not be specified when either `exclude_regex` or `exclude` are specified. 
 
 ### Example
 
-Resource configuration
+Resource configuration with exclusions
 
 ```yaml
 resources:
@@ -29,6 +30,19 @@ resources:
     exclude:
     - irrelevant
     - legacy-service
+```
+
+Resource configuration with an inclusion regex
+
+```yaml
+resources:
+- name: repo-list
+  type: github-list-repos
+  source:
+    access-token: 1234567890abcdef
+    org: myorg
+    team: myteam
+    include_regex: "^myprefix-"
 ```
 
 ## Behavior

--- a/src/check
+++ b/src/check
@@ -1,8 +1,15 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
+set -euxo pipefail
 
-source /opt/resource/util.sh
+util_loc="/opt/resource/util.sh"
+
+if [[ ! -f "${util_loc}" ]]; then
+  util_loc="./util.sh"
+fi
+
+# shellcheck source=./util.sh
+source ${util_loc}
 
 input_json="$(cat)"
 resource_version_hash=

--- a/src/check-dev.sh
+++ b/src/check-dev.sh
@@ -7,10 +7,11 @@ auth_token=$(security find-generic-password -a "ari-becker" -s "Github Repos Per
 echo "{
   \"source\": {
     \"auth_token\": \"${auth_token}\",
+    \"include_regex\" : \"^infra-\",
     \"org\"       : \"coralogix\"
   }
-}" | ../src/check
+}" | ./check
 
 # \"team\"      : \"ops\",
 # \"exclude\"   : [\"categorization\", \"webapi\"],
-# \"exclude_regex\" : \"infra|sdk|eng-\"
+# \"exclude_regex\" : \"infra|sdk|eng-\",

--- a/src/in
+++ b/src/in
@@ -4,10 +4,16 @@ set -euo pipefail
 
 destination_dir=$1
 
-source /opt/resource/util.sh
+util_loc="/opt/resource/util.sh"
+
+if [[ ! -f "${util_loc}" ]]; then
+  util_loc="./util.sh"
+fi
+
+# shellcheck source=./util.sh
+source ${util_loc}
 
 input_json="$(cat)"
-response=
 repository_total_count=
 
 org=$(              echo "${input_json}" | jq '.source.org'                     -r)

--- a/src/in-dev.sh
+++ b/src/in-dev.sh
@@ -4,15 +4,20 @@ set -euxo pipefail
 
 auth_token=$(security find-generic-password -a "ari-becker" -s "Github Repos Personal Access Token" -w | tr -d " \n")
 
+if [[ ! -d $1 ]]; then
+  mkdir -p $1
+fi
+
 echo "{
   \"source\": {
-    \"auth_token\": \"${auth_token}\",
-    \"org\"       : \"coralogix\"
+    \"auth_token\"    : \"${auth_token}\",
+    \"include_regex\" : \"^infra-\",
+    \"org\"           : \"coralogix\"
   },
   \"version\": {
-    \"hash\": \"09fc854f15daf805a74cafd0d94d292913de78269960401fabc1697f6ce7850cd17c1ed5c89f2145d9a7ea218bf56230d6759f471bde464a39a1e71bbc2debac\"
+    \"hash\": \"d02bdee2cd80e6ec25be6c75a2ee51968c0daaebdb2c68f522c10b5bf26df38fcc31787e415f5914aeba10f73a3b8636b409da485b69b2eb61462c9699b82cf8\"
   }
-}" | ../src/in $1
+}" | ./in $1
 
 # \"team\"      : \"ops\",
 # \"exclude\"   : [\"categorization\", \"webapi\"],


### PR DESCRIPTION
You may now specify an `include_regex` source parameter. This filters the names of the repositories to only those which match the regular expression.